### PR TITLE
fix: quote procfile command output

### DIFF
--- a/commands/main.go
+++ b/commands/main.go
@@ -22,6 +22,8 @@ func parseProcfile(path string, delimiter string, strict bool) ([]procfile.Procf
 	return procfile.ParseProcfile(text, delimiter, strict)
 }
 
+// expandEnv expands environment variables in a Procfile command using multiple sources:
+// built-in vars (PS, PORT), optional .env file, and system environment variables
 func expandEnv(e procfile.ProcfileEntry, envPath string, allowEnv bool, defaultPort int) (string, error) {
 	baseExpandFunc := func(key string) string {
 		if key == "PS" {

--- a/commands/show.go
+++ b/commands/show.go
@@ -8,6 +8,7 @@ import (
 	"github.com/josegonzalez/cli-skeleton/command"
 	"github.com/posener/complete"
 	flag "github.com/spf13/pflag"
+	"gopkg.in/alessio/shellescape.v1"
 )
 
 type ShowCommand struct {
@@ -120,7 +121,7 @@ func (c *ShowCommand) Run(args []string) int {
 		return 1
 	}
 
-	c.Ui.Output(command)
+	c.Ui.Output(shellescape.Quote(command))
 
 	return 0
 }


### PR DESCRIPTION
I [have a procfile](https://github.com/iloveitaly/python-starter-template/blob/04cfd545d8414e2d4292b67df8fbe91317dd186d/Procfile#L5) which resulted in `python main` as the CMD.

However, it wasn't quoted, so the `main.py` was effectively dropped when starting the container with dokku:

```
docker container create --env=ALLOWED_HOST_LIST --env=DATABASE_URL --env=DOKKU_APP_RESTORE --env=DOKKU_APP_TYPE --env=DOKKU_CHECKS_DISABLED --env=DOKKU_CHECKS_SKIPPED --env=DOKKU_PROXY_PORT --env=EMAIL_FROM_ADDRESS --env=GIT_REV --env=LOG_LEVEL --env=OPENAI_API_KEY --env=PORT --env=PYTHON_ENV --env=REDIS_URL --env=SENTRY_DSN --env=SESSION_SECRET_KEY --env=SMTP_URL --link dokku.postgres.movie_tickets_postgres:dokku-postgres-movie-tickets-postgres --link dokku.redis.movie-tickets-redis:dokku-redis-movie-tickets-redis --restart=on-failure:10 --label=com.dokku.process-type=api --label=com.dokku.dyno=api.1 --env=DYNO=api.1 --name=movie-tickets.api.1.upcoming-21928 --init --label=com.dokku.app-name=movie-tickets --label=com.dokku.container-type=deploy --label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=dokku --log-opt=max-size=10m --env=TRACE=true --env=PORT= dokku/movie-tickets:latest python main.py
```

Which caused the container to exit early without any output. Quoting the cmd in the Procfile fixed the issue for me:

```
api: 'python main.py'
```

But it took me awhile to find the issue.

I'm not familiar with go, and I wasn't able to compile this locally because I'm on macOS arm, but I *think* this is close to what we need to do to fix this issue. I can find a x86 ubuntu box to test this on if this looks like the generally right approach.
