### PR TITLE
feat: publish deb packages for ubuntu 26.04 (resolute)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,11 +165,13 @@ release-packagecloud:
 release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb build/deb/$(NAME)_$(VERSION)_arm64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy   build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/noble   build/deb/$(NAME)_$(VERSION)_amd64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/resolute build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bullseye build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bookworm build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/trixie   build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy    build/deb/$(NAME)_$(VERSION)_arm64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/noble    build/deb/$(NAME)_$(VERSION)_arm64.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/resolute build/deb/$(NAME)_$(VERSION)_arm64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bullseye build/deb/$(NAME)_$(VERSION)_arm64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bookworm build/deb/$(NAME)_$(VERSION)_arm64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/trixie   build/deb/$(NAME)_$(VERSION)_arm64.deb


### PR DESCRIPTION
Dokku is adding Ubuntu 26.04 LTS ("Resolute Raccoon", codename `resolute`) support, and this project's `.deb` packages are published to the `dokku/dokku` PackageCloud repository. The `release-packagecloud-deb` Makefile target previously pushed Ubuntu builds only to `ubuntu/jammy` (22.04) and `ubuntu/noble` (24.04), so users on 26.04 could not install `procfile-util` from the configured repository.

This adds an `ubuntu/resolute` push for both the `amd64` and `arm64` packages, mirroring the existing `ubuntu/noble` lines so the next tagged release publishes packages for 26.04.

Cutting the release itself remains a maintainer action: pushing a git tag triggers the `tagged-release` workflow, which runs `make release-packagecloud`.

Fixes #347
Ref dokku/dokku#8768
