### PR TITLE
chore: bump json to 2.21.2 to fix CVE-2026-54696

### DIFF
--- a/.github/Gemfile.lock
+++ b/.github/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
     http-cookie (1.1.0)
       domain_name (~> 0.5)
     insist (1.0.0)
-    json (2.15.2.1)
+    json (2.21.2)
     logger (1.7.0)
     mime-types (3.7.0)
       logger


### PR DESCRIPTION
The `json` gem was pinned at `2.15.2.1` in `.github/Gemfile.lock`, within the range affected by CVE-2026-54696 (GHSA-x2f5-4prf-w687), a heap out-of-bounds write in the JSON generator's IO-streaming path that can crash the process. It is a transitive dependency of `package_cloud` used only when building and publishing release packages in CI, and bumping to `2.21.2` moves it out of the vulnerable `< 2.19.9` range.